### PR TITLE
Move from Python to Actions language for CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - language: python # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
+          - language: actions # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
             build-mode: none
     steps:
       - name: Checkout repository


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

You’re basically reading the situation correctly: if your repo has •no Python source files•, then running CodeQL “as Python” is mostly a category error. CodeQL builds a database from *source code in the repository* and then runs semantic queries over that database. A `requirements.txt` (even with hashes) tells you about dependencies, but it is not something CodeQL can meaningfully treat as “Python code to analyze.” ([[GitHub Docs](https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/configuring-advanced-setup-for-code-scanning?utm_source=chatgpt.com)][1])

That said, I would not jump straight from “Python CodeQL fails” to “CodeQL is useless here.” You have a *better* way to use CodeQL in this repo that (a) stops the failure, (b) gives you real security value, and (c) still satisfies the OpenSSF Scorecard “SAST” heuristic.

## What CodeQL is (and is not) buying you in this repo

### Why Python-mode CodeQL is failing

CodeQL’s core workflow is: detect/select language(s) → build a CodeQL database for that language from repo contents → run queries. If there’s no Python source, there’s no Python database to build, so the analysis falls over (or produces “nothing to analyze”–style outcomes depending on setup). ([[GitHub Docs](https://docs.github.com/en/code-security/code-scanning/troubleshooting-code-scanning/some-languages-not-analyzed?utm_source=chatgpt.com)][2])

A pinned `requirements.txt` helps with:

* dependency reproducibility and supply chain integrity
* vulnerability management when paired with a scanner (pip-audit, OSV-Scanner, Dependabot, etc.)

It does *not* create any Python code surface for CodeQL to reason about.

### Where the risk *actually* lives in certbotbot

From your description, the security-sensitive surfaces look like:

* GitHub Actions workflows (especially anything touching AWS credentials, OIDC, artifacts, caching, checkout, permissions)
* Shell scripting (input handling, quoting, unsafe expansion, temp files, tar extraction, path traversal-ish footguns)
* Container build chain (base image provenance, apt/pip installs, runtime user, file permissions)
* Dependency and artifact trust (tarball from S3 + post-processing + upload back to S3)

In other words: this is “automation + supply chain” risk more than “Python code vulnerability” risk.

## The better CodeQL fit: scan GitHub Actions workflows (language = `actions`)

GitHub added first-class CodeQL analysis for GitHub Actions workflow files (YAML) and action metadata. It’s GA as of April 22, 2025. ([[The GitHub Blog](https://github.blog/changelog/2025-04-22-github-actions-workflow-security-analysis-with-codeql-is-now-generally-available/?utm_source=chatgpt.com)][3])

This is a *really* good match for your repo because it directly targets the part that can accidentally create high-impact compromise paths (credential exfil, code injection via untrusted inputs, unsafe checkout contexts, missing/overbroad permissions, unpinned actions, artifact poisoning patterns, etc.). GitHub even documents the built-in query set for workflow analysis. ([[GitHub Docs](https://docs.github.com/en/code-security/code-scanning/reference/code-ql-built-in-queries/actions-built-in-queries?utm_source=chatgpt.com)][4])

Also: the CodeQL action’s own workflow uses `actions` as a language in its matrix, so this isn’t “clever hack,” it’s an expected use case. ([[GitHub](https://github.com/github/codeql-action/blob/main/.github/workflows/codeql.yml?utm_source=chatgpt.com)][5])

### What I’d do, concretely

1. **Stop telling CodeQL to analyze Python** (for now).
2. **Configure CodeQL to analyze `actions`**.
3. Use **build-mode: none** (since there’s nothing to build for workflows anyway, and you’re not compiling code). You can see CodeQL itself using `build-mode: none` in its workflow examples. ([[GitHub](https://github.com/github/codeql-action/blob/main/.github/workflows/codeql.yml?utm_source=chatgpt.com)][5])

This should eliminate the failure while producing actionable findings in exactly the area where this repo is most exposed.

## Scorecard reality: “SAST” is heuristic, and it tends to recognize CodeQL specifically

Scorecard’s SAST check is heuristic-driven, and in practice it has historically been very “CodeQL-centric.” There’s even discussion/issues around how it detects CodeQL usage and what “counts.” ([[GitHub](https://github.com/ossf/scorecard/issues/3817?utm_source=chatgpt.com)][6])

So you have three pragmatic options:

### Option A (my recommendation): Keep CodeQL, but aim it where it fits

* Switch CodeQL to `actions`
* Keep MegaLinter doing the heavy lifting for shell/Docker/deps/etc.

This gives you:

* Scorecard “sees” CodeQL present
* CodeQL actually returns useful results (workflow analysis)
* No need to rewrite your Bash script purely for compliance

### Option B: Accept the Scorecard hit, document why, and lean on MegaLinter + SARIF uploads

If you’re philosophically opposed to running a tool that doesn’t fit, you can:

* remove CodeQL
* publish MegaLinter results into GitHub’s code scanning UI (SARIF upload)

That is “real SAST,” but Scorecard may still not give you credit depending on its detection logic. (This is the classic “compliance checkbox vs meaningful control” tradeoff you’re already feeling.)

### Option C: Rewrite the Bash workflow into Python *because you actually want Python*

This is only worth it if you want the benefits of a Python implementation on their own merits (testability, structure, typed interfaces, easier unit tests/mocking for AWS calls, safer handling of tar extraction, etc.). Doing it *only* to make CodeQL happy is usually a poor trade.

## Should you rewrite the shell script into Python?

Here’s the honest trade:

### Reasons to keep Bash

* The workflow is fundamentally orchestration glue: download → unpack → run certbot → post-process → upload.
* Shellcheck + strict mode + careful quoting gets you a long way.
* MegaLinter already gives you broad coverage in this space.

### Reasons to move to Python

* If inputs are complex or you’re doing non-trivial parsing/logic, Python becomes safer and more maintainable.
* You can add unit tests around the “danger zones” (tar handling, path normalization, AWS interactions).
* You can use libraries that reduce footguns (e.g., boto3 patterns, safer file handling, structured logging).

### Middle-ground that often wins

Keep the Bash entrypoint, but move the “logic core” into a small Python module *only if*:

* you want tests
* you want clearer structure
* you want to reduce shell quoting / parsing risk

If you do that, CodeQL Python becomes legitimately useful. If you do not need that, you are paying complexity tax for a compliance artifact.

## What “good” looks like for certbotbot, in layered controls

If I were tuning this repo for maximum real-world security (not just a Scorecard number), I’d target the risk surfaces directly:

1. **CodeQL (Actions workflows)** – catch workflow misconfigs and exploitation patterns ([[The GitHub Blog](https://github.blog/changelog/2025-04-22-github-actions-workflow-security-analysis-with-codeql-is-now-generally-available/?utm_source=chatgpt.com)][3])
2. **MegaLinter** – shellcheck, hadolint, etc. (you already have this)
3. **Dependency vuln scanning** – pip-audit / OSV-scanner / Dependabot (since requirements are meaningful here)
4. **Container scanning** – Trivy/Grype on the built image
5. **Workflow hardening** – least-privilege `permissions:`, pinned actions, constrain `pull_request` contexts, avoid risky `checkout` patterns, etc. (CodeQL Actions queries explicitly look for a bunch of these classes) ([[GitHub Docs](https://docs.github.com/en/code-security/code-scanning/reference/code-ql-built-in-queries/actions-built-in-queries?utm_source=chatgpt.com)][4])

That stack matches the repo’s reality: it’s an automation + artifact pipeline more than an application codebase.

## Bottom line

* If you keep CodeQL configured for Python with no Python source: yes, it’s largely “not a match,” and the failure is a symptom of that mismatch. ([[GitHub Docs](https://docs.github.com/en/code-security/code-scanning/troubleshooting-code-scanning/some-languages-not-analyzed?utm_source=chatgpt.com)][2])
* If you want CodeQL here *and* want it to be meaningful: switch it to analyzing GitHub Actions workflows (`actions`). That’s now a first-class use case and is directly aligned with the real attack surface in this repo. ([[The GitHub Blog](https://github.blog/changelog/2025-04-22-github-actions-workflow-security-analysis-with-codeql-is-now-generally-available/?utm_source=chatgpt.com)][3])
* Rewriting Bash to Python solely to satisfy Scorecard is usually not worth it. Rewriting because you want tests/structure/safer logic can be worth it.

If you want, paste (or point me at) your current `.github/workflows/codeql*.yml` and I’ll propose an exact minimal diff to flip it to `actions` analysis (and stop the Python failures) while keeping whatever scheduling/triggers you already have.

[1]: https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/configuring-advanced-setup-for-code-scanning?utm_source=chatgpt.com "Configuring advanced setup for code scanning - GitHub Docs"
[2]: https://docs.github.com/en/code-security/code-scanning/troubleshooting-code-scanning/some-languages-not-analyzed?utm_source=chatgpt.com "Some languages were not analyzed with CodeQL advanced setup"
[3]: https://github.blog/changelog/2025-04-22-github-actions-workflow-security-analysis-with-codeql-is-now-generally-available/?utm_source=chatgpt.com "GitHub Actions workflow security analysis with CodeQL is now generally ..."
[4]: https://docs.github.com/en/code-security/code-scanning/reference/code-ql-built-in-queries/actions-built-in-queries?utm_source=chatgpt.com "GitHub Actions queries for CodeQL analysis - GitHub Docs"
[5]: https://github.com/github/codeql-action/blob/main/.github/workflows/codeql.yml?utm_source=chatgpt.com "codeql-action/.github/workflows/codeql.yml at main · github/codeql-action"
[6]: https://github.com/ossf/scorecard/issues/3817?utm_source=chatgpt.com "Does not detect use of CodeQL (SAST) #3817 - GitHub"

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. …
2. …
3. …

## Readiness Checklist

- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
